### PR TITLE
Working doc for edge|node|individual values & spotted an error

### DIFF
--- a/docs/individual_node_edge.md
+++ b/docs/individual_node_edge.md
@@ -1,0 +1,222 @@
+---
+kernelspec:
+  name: python3
+  display_name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: '0.13'
+    jupytext_version: 1.13.8
+---
+
+```{eval-rst}
+.. currentmodule:: tstrait
+```
+
+(genetic_individual_node_edge_doc)=
+
+# Individual, node, and edge genetic values
+
+In line with the {ref}`tree sequence data model<tskit:sec_data_model>`,
+this page will describe relationships between individual, node, and edge genetic values, and underlying allele effects.
+
+**Learning Objectives**
+
+After this page, you will be able to:
+
+- Understand how to obtain genetic value in tstrait for individuals, nodes, and edges
+- Understand how allele effects give rise to different genetic values
+- Understand how to use allele effect model and mutation effect model in tstrait (TODO: later - move to a separate page?)
+
+# Algorithm Overview
+
+The tstrait algorithm used for computing
+{ref}`individuals' genetic values<genetic_value_doc>` from allele effects
+can also be used to compute node and edge genetic values.
+These are related as follows:
+
+- *edge effect* is a sum of allele effects on the edge.
+- *edge "genetic" value* is a sum of edge effects above the edge and the edge.
+- *node "genetic" value* is a sum of "genetic" values of incoming edges into the node.
+- *individual genetic value* is a sum of "genetic" values of nodes of the individual.
+
+Above we have quoted the term "genetic" when refering to nodes and edges,
+because that term is usually used for individuals.
+For consistency across different tstrait outputs,
+we use the same term (genetic value) for individuals, nodes, and edges.
+
+# Example
+
+We will demonstrate the concepts of edge, node, and individual genetic values with
+a tiny example so we can follow the computations.
+
+```{code-cell}
+import io
+import tskit
+import tstrait
+import pandas as pd
+
+individuals = io.StringIO(
+    """\
+    flags location parents
+        0        0      -1
+        0        0      -1
+    """
+)
+
+nodes = io.StringIO(
+    """\
+    id is_sample time individual
+     0         1    0          0
+     1         1    0          0
+     2         1    0          1
+     3         1    0          1
+     4         0    1         -1
+     5         0    1         -1
+     6         0    2         -1
+     7         0    4         -1
+    """
+)
+
+edges = io.StringIO(
+    """\
+    left right parent child
+       0    10      4     0
+       0     5      4     1
+       5    10      5     1
+       0    10      5     2
+       0    10      6     3
+       0    10      6     5
+       0    10      7     4
+       0    10      7     6
+    """
+)
+
+sites = io.StringIO(
+  """\
+  position ancestral_state
+         0               0
+         1               0
+         2               0
+         3               0
+         4               0
+         5               0
+         6               0
+         7               0
+         8               0
+         9               0
+  """
+)
+
+mutations = io.StringIO(
+  """\
+  site node time derived_state parent
+     0    4  3.0             1     -1
+     1    3  1.5             1     -1
+     2    1  0.5             1     -1
+     4    4  2.0             1     -1
+     6    6  3.0             1     -1
+     7    5  1.5             1     -1
+     8    3  1.0             1     -1
+     9    1  0.5             1     -1
+  """
+)
+
+ts = tskit.load_text(individuals = individuals, 
+                     nodes = nodes,
+                     edges = edges,
+                     sites = sites,
+                     mutations = mutations,
+                     strict = False)
+print(ts)
+
+ts.genotype_matrix().T
+# 0 [1, 0, 0, 0, 1, 0, 0, 0, 0, 0]
+# 1 [1, 0, 1, 0, 1, 0, 1, 1, 0, 1]
+# 2 [0, 0, 0, 0, 0, 0, 1, 1, 0, 0]
+# 3 [0, 1, 0, 0, 0, 0, 1, 0, 1, 0]
+
+#        mutation           0    1    2    3    4    5    6    7
+data = {"site_id":       [  0,   1,   2,   4,   6,   7,   8,   9],
+        "effect_size":   [  2,   1,  -1,  -1,  -1,  -1,   1,   1],
+        "trait_id":      [  0,   0,   0,   0,   0,   0,   0,   0],
+        "causal_allele": ["1", "1", "1", "1", "1", "1", "1", "1"]}
+trait_df = pd.DataFrame(data)
+trait_df
+```
+
+We obtain **edge effects** by using the {py:func}`edge_effect` function:
+
+```{code-cell}
+edge_effect_df = tstrait.edge_effect(ts, trait_df)
+edge_effect_df
+# ALL VALUES ARE CORRECT!
+```
+
+The above output is a {py:class}`pandas.DataFrame` object with the following columns:
+
+> - **trait_id**: Trait ID that will be used in multi-trait simulation.
+> - **edge_id**: Edge ID inside the tree sequence input.
+> - **effect_size**: Simulated edge effect.
+
+We obtain **edge genetic values** by using the `mode="edge"` argument
+of the {py:func}`genetic_value` function:
+
+```{code-cell}
+edge_value_df = tstrait.genetic_value(ts, trait_df, mode="edge")
+edge_value_df
+# ERROR: Edge 1 should have value 1, but has 0!
+```
+
+The above output is a {py:class}`pandas.DataFrame` object with the following columns:
+
+> - **trait_id**: Trait ID that will be used in multi-trait simulation.
+> - **edge_id**: Edge ID inside the tree sequence input.
+> - **genetic_value**: Simulated edge genetic value.
+
+We obtain **node genetic values** by using the `mode="node"` argument
+of the {py:func}`genetic_value` function:
+
+```{code-cell}
+node_value_df = tstrait.genetic_value(ts, trait_df, mode="node")
+node_value_df
+# ERROR: Node 1 should have value 0, but has -1 (due to incoming edge 1 having wrong value)
+```
+
+The above output is a {py:class}`pandas.DataFrame` object with the following columns:
+
+> - **trait_id**: Trait ID that will be used in multi-trait simulation.
+> - **node_id**: Node ID inside the tree sequence input.
+> - **genetic_value**: Simulated node genetic value.
+
+We obtain **individual genetic values** by using the `mode="individual"` argument
+of the {py:func}`genetic_value` function, which is the default mode:
+
+```{code-cell}
+individual_value_df = tstrait.genetic_value(ts, trait_df)
+individual_value_df
+# ERROR: Individual 0 should have value 1, but has 0 (due to incoming edge 1 / node 1 having wrong value)!
+```
+
+The above output is a {py:class}`pandas.DataFrame` object with the following columns:
+
+> - **trait_id**: Trait ID that will be used in multi-trait simulation.
+> - **individual_id**: Individual ID inside the tree sequence input.
+> - **genetic_value**: Simulated Individual genetic value.
+
+# Allele and mutation effect models
+
+TODO: Later
+Show how this is done in tstrait.
+Move to a separate page?
+
+tstrait by default uses the allele effect model.
+This model assumes that an allele has appeared with mutation once
+in the tree sequence and that the effect of this allele is the same
+for all individuals carrying this allele.
+
+tstrait also supports the mutation effect model.
+This models assumes that an allele can appear with mutation multiple times
+in the tree sequence and that the effect of the resulting alleles differs
+between mutation events and correspondingly for individuals carrying these alleles.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -20,7 +20,9 @@ data structures.
 
 Quantitative trait simulation in tstrait is transparent, and users can control each step in the simulation. Thus,
 it is possible for the users to simulate their own environmental noise on top of simulated genetic values,
-or even use their own defined effect sizes and causal sites. The tree sequence data structure is widely used in
+or even use their own defined effect sizes and causal sites.
+Users can also study how tree sequence nodes and edges contribute to individuals' genetic values.
+The tree sequence data structure is widely used in
 various population genetic simulation packages, including [SLiM](https://messerlab.org/slim/),
 [msprime](msprime:sec_intro), and [stdpopsim](stdpopsim:sec_introduction); it is therefore easy for
 users of these packages to add quantitative traits to their results using tstrait.
@@ -31,7 +33,7 @@ To learn more about tree sequences:
 
 - The [tskit website](https://tskit.dev/) provides [learning materials](https://tskit.dev/learn/) explaining
   what tree sequences are, and includes tutorials, publications and videos.
-- The [PySLiM manual](pyslim:sec_introduction) explains how forward genetic simulation can be create
+- The [PySLiM manual](pyslim:sec_introduction) explains how forward-time genetic simulation can create
   tree sequences.
 - The [msprime manual](msprime:sec_intro) details an efficient backward-time genetic simulator that outputs
   tree sequences.

--- a/tstrait/__init__.py
+++ b/tstrait/__init__.py
@@ -27,7 +27,7 @@ from .trait_model import (
 )  # noreorder
 from .genetic_value import (
     genetic_value,
-    edge_effect_size,
+    edge_effect,
     normalise_genetic_value,
 )  # noreorder
 from .simulate_environment import (

--- a/tstrait/genetic_value.py
+++ b/tstrait/genetic_value.py
@@ -16,7 +16,7 @@ def _compute_nodes_genetic_value(
     effect_size,
 ):  # pragma: no cover
     """
-    Compute the genetic value of each node for the specified set of mutations
+    Compute the node genetic values for the specified set of mutations
     encoded in the stack.
     """
     genetic_value = np.zeros(num_nodes)
@@ -36,7 +36,7 @@ def _accumulate_individual_values(
     nodes_genetic_value, nodes_individual, num_nodes, num_individuals
 ):  # pragma: no cover
     """
-    Accumulate the genetic values by summing their node contributions.
+    Accumulate the individual genetic values by summing their node contributions.
     """
     individuals_genetic_value = np.zeros(num_individuals)
     for u in range(num_nodes):
@@ -50,7 +50,7 @@ def _accumulate_edge_values(
     nodes_genetic_value, nodes_edge, num_nodes, num_edges
 ):  # pragma: no cover
     """
-    Accumulate the genetic values by summing their node contributions.
+    Accumulate the edge genetic values by summing their node contributions.
     """
     edges_genetic_value = np.zeros(num_edges)
     for u in range(num_nodes):
@@ -61,7 +61,8 @@ def _accumulate_edge_values(
 
 
 class _GeneticValue:
-    """GeneticValue class to compute genetic values of individuals.
+    """
+    GeneticValue class to compute genetic values of individuals, nodes, or edges.
 
     Parameters
     ----------
@@ -83,6 +84,9 @@ class _GeneticValue:
     # TODO add a better interface here to allow easy testing across the
     # different modes.
     def _individual_genetic_values(self, tree, site, causal_allele, effect_size):
+        """
+        Returns a numpy array with individual genetic values.
+        """
         genetic_value = self._node_genetic_values(
             tree=tree,
             site=site,
@@ -96,8 +100,7 @@ class _GeneticValue:
 
     def _node_genetic_values(self, tree, site, causal_allele, effect_size):
         """
-        Returns a numpy array that describes the genetic of all nodes at
-        a particular site.
+        Returns a numpy array with node genetic values.
         """
         has_mutation = np.zeros(self.ts.num_nodes + 1, dtype=bool)
         state_transitions = {tree.virtual_root: site.ancestral_state}
@@ -124,7 +127,7 @@ class _GeneticValue:
 
     def _run(self, mode):
         """
-        Computes genetic values of individuals, nodes or edges
+        Computes genetic values of individuals, nodes, or edges
         depending on the value of "mode"
 
         Returns
@@ -186,12 +189,14 @@ def genetic_value(ts, trait_df, mode="individual"):
         simulation.
     trait_df : pandas.DataFrame
         Trait dataframe.
+    mode : TODO
+        TODO.
 
     Returns
     -------
     pandas.DataFrame
-        Pandas dataframe that includes genetic value of individuals in the
-        tree sequence.
+        Pandas dataframe that includes genetic value of individuals, edges, or
+        nodes in the tree sequence.
 
     See Also
     --------
@@ -224,7 +229,7 @@ def genetic_value(ts, trait_df, mode="individual"):
     The genetic value dataframe contains the following columns:
 
         * **trait_id**: Trait ID.
-        * **individual_id**: Individual ID inside the tree sequence input.
+        * **individual_id**: Individual ID inside the tree sequence input. TODO
         * **genetic_value**: Genetic values that are obtained from the trait dataframe.
 
     Examples
@@ -254,7 +259,11 @@ def genetic_value(ts, trait_df, mode="individual"):
     return genetic_result
 
 
-def edge_effect_size(ts, trait_df):
+def edge_effect(ts, trait_df):
+    """
+    Compute the effect of each edge in the tree sequence.
+    TODO: Add more details on ts, trait_df etc.
+    """
     ts = _check_instance(ts, "ts", tskit.TreeSequence)
     trait_df = _check_dataframe(
         trait_df, ["site_id", "effect_size", "trait_id", "causal_allele"], "trait_df"
@@ -292,7 +301,8 @@ def edge_effect_size(ts, trait_df):
 
 
 def normalise_genetic_value(genetic_df, mean=0, var=1, ddof=1):
-    """Normalise genetic value dataframe.
+    """
+    Normalise genetic value dataframe.
 
     Parameters
     ----------


### PR DESCRIPTION
@jeromekelleher I worked on this a bit. Specifically, I added a doc with a tiny example that would demonstrate the logic and functionality. I spotted an error in the output (see the `docs/individual_node_edge.md` file), but I don't yet know where the error is coming from. I will keep digging ...

Here is the graphical visualisation of the tiny example:

ARG with allele sequence

<img width="1239" alt="Screenshot 2024-10-07 at 09 17 51" src="https://github.com/user-attachments/assets/eb423623-0373-41ef-9aae-7b307c21248b">

Note that node IDs are in letters in the plot and mapping is a=0, b=1, c=2, d=3, e=4, f=5, g=6, h=7

ARG with values (here the visualisation has edges split upwards)

<img width="1264" alt="Screenshot 2024-10-07 at 09 18 06" src="https://github.com/user-attachments/assets/6f62e44a-bba9-43aa-95dd-1f50b78f1673">

We have an issue (shown in `docs/individual_node_edge.md`) with the edge value for edge 1 and node value for node 1, and hence individual genetic value for individual 1. Everything else is correct, including edge effect for the edge 1.